### PR TITLE
Fix Bug where Interaction Text Stayed on Screen and Clean Up `InteractorUse.cs`

### DIFF
--- a/code/Player/InteractorUse.cs
+++ b/code/Player/InteractorUse.cs
@@ -4,11 +4,6 @@ public sealed class InteractorUse : Component
 	private ItemPickUp _pickupPanel { get; set; }
 	private TimeSince _timeSinceUse { get; set; }
 
-	protected override void OnUpdate()
-	{
-
-	}
-
 	protected override void OnFixedUpdate()
 	{
 		base.OnFixedUpdate();
@@ -55,7 +50,6 @@ public sealed class InteractorUse : Component
 						_pickupPanel = new ItemPickUp( $"Get {item.Item.Name}", interactor.Cost, false );
 						itemUI.Panel.AddChild( _pickupPanel );
 					}
-
 				}
 				else
 				{
@@ -80,7 +74,6 @@ public sealed class InteractorUse : Component
 		InteractObject = null;
 		DestroyUI();
 	}
-
 
 	public void DestroyUI()
 	{

--- a/code/Player/InteractorUse.cs
+++ b/code/Player/InteractorUse.cs
@@ -1,8 +1,8 @@
-using Sandbox;
-
 public sealed class InteractorUse : Component
 {
 	GameObject InteractObject { get; set; }
+	private ItemPickUp _pickupPanel { get; set; }
+	private TimeSince _timeSinceUse { get; set; }
 
 	protected override void OnUpdate()
 	{
@@ -13,53 +13,55 @@ public sealed class InteractorUse : Component
 	{
 		base.OnFixedUpdate();
 
-		var tr = Scene.Trace.Ray(Scene.Camera.Transform.Position, Scene.Camera.Transform.Position + Scene.Camera.Transform.Rotation.Forward * 100)
-			.Radius(20)
-			.WithTag("interactable")
+		var tr = Scene.Trace.Ray( Scene.Camera.Transform.Position, Scene.Camera.Transform.Position + Scene.Camera.Transform.Rotation.Forward * 100 )
+			.Radius( 20 )
+			.WithTag( "interactable" )
 			.Run();
 
-		if (tr.Hit)
+		if ( tr.Hit )
 		{
 			var interactor = tr.GameObject.Components.Get<Interactable>();
-			if (interactor != null)
+			if ( interactor != null )
 			{
+				//Wait a moment before interacting again to avoid interacting with two items in the same frame
+				if ( _timeSinceUse < 0.1f ) return;
+
 				if ( interactor.IsOpen ) return;
 
-				if (Input.Pressed("use"))
+				if ( Input.Pressed( "use" ) )
 				{
-					interactor.OnInteract(GameObject);
-					DestroyUI();
+					interactor.OnInteract( GameObject );
+					_timeSinceUse = 0f;
+					ClearInteractor();
 					return;
 				}
 
-				var parent = GameObject.Parent;
-				var ui = parent.Components.Get<ScreenPanel>( FindMode.EnabledInSelfAndDescendants );
-				var itemUI = ui.Components.Get<ItemsUI>( FindMode.EnabledInSelfAndDescendants );
+				var itemUI = ItemsUI.Instance;
 
-				if(itemUI.Panel.Children.FirstOrDefault( x => x is ItemPickUp ) != null) return;
+				if ( _pickupPanel != null ) return;
 
-				var item = interactor.Components.Get<ItemHelper>(FindMode.EnabledInSelfAndChildren);
+				var item = interactor.Components.Get<ItemHelper>( FindMode.EnabledInSelfAndChildren );
 				if ( item != null )
 				{
-					if(item.Equipment != null)
+					if ( item.Equipment != null )
 					{
 						//Log.Info( "Equipment component found" );
-						var pickupui = new ItemPickUp( $"Get {item.Equipment.Name}", interactor.Cost, false );
-						itemUI.Panel.AddChild( pickupui );
+						_pickupPanel = new ItemPickUp( $"Get {item.Equipment.Name}", interactor.Cost, false );
+						itemUI.Panel.AddChild( _pickupPanel );
 					}
 					else
 					{
 						//Log.Info( "Item component found" );
-						var pickupui = new ItemPickUp( $"Get {item.Item.Name}", interactor.Cost, false );
-						itemUI.Panel.AddChild( pickupui );
+						_pickupPanel = new ItemPickUp( $"Get {item.Item.Name}", interactor.Cost, false );
+						itemUI.Panel.AddChild( _pickupPanel );
 					}
 
 				}
 				else
 				{
 					Log.Info( "No item component found" );
-					var pickupui = new ItemPickUp( interactor.Name, interactor.Cost, interactor.HasPrice );
-					itemUI.Panel.AddChild( pickupui );
+					_pickupPanel = new ItemPickUp( interactor.Name, interactor.Cost, interactor.HasPrice );
+					itemUI.Panel.AddChild( _pickupPanel );
 				}
 
 				InteractObject = tr.GameObject;
@@ -69,51 +71,24 @@ public sealed class InteractorUse : Component
 		}
 		else
 		{
-			DestroyUI();
+			ClearInteractor();
 		}
 	}
 
-	void CreateGlow()
+	public void ClearInteractor()
 	{
-		if(InteractObject == null) return;
-
-		foreach (var child in InteractObject.Children)
-		{
-			if (child.Components.Get<HighlightOutline>() != null)
-			{
-				var outline = child.Components.Get<HighlightOutline>();
-				outline.Enabled = true;
-			}
-		}
-	}
-
-	void DestroyGlow()
-	{
-		if(InteractObject == null) return;
-
-		foreach (var child in InteractObject.Children)
-		{
-			if (child.Components.Get<HighlightOutline>() != null)
-			{
-				var outline = child.Components.Get<HighlightOutline>();
-				outline.Enabled = false;
-			}
-		}
+		InteractObject = null;
+		DestroyUI();
 	}
 
 
 	public void DestroyUI()
 	{
+		_pickupPanel?.Delete();
+		_pickupPanel = null;
+
 		var interactor = InteractObject?.Components.Get<Interactable>();
-		if (interactor == null) return;
+		if ( interactor == null ) return;
 		interactor.DestroyGlow();
-
-		var parent = GameObject.Parent;
-		var ui = parent.Components.Get<ScreenPanel>( FindMode.EnabledInSelfAndDescendants );
-		var itemUI = ui.Components.Get<ItemsUI>( FindMode.EnabledInSelfAndDescendants );
-
-		itemUI.Panel.Children.FirstOrDefault( x => x is ItemPickUp )?.Delete();
-
-		//InteractObject = null;
 	}
 }

--- a/code/UI/Player/ItemsUI.razor
+++ b/code/UI/Player/ItemsUI.razor
@@ -30,6 +30,13 @@
 {
 	ItemsUIToolTip itemsUIToolTip;
 
+	public static ItemsUI Instance;
+
+	public ItemsUI()
+	{
+		Instance = this;
+	}
+
 	public void OnItemHover(ItemDef item)
 	{
 		if (item != null)

--- a/code/Weapons/BaseWeaponItem.cs
+++ b/code/Weapons/BaseWeaponItem.cs
@@ -1,9 +1,6 @@
-using RogueFPS;
-using Sandbox;
-
 public class BaseWeaponItem : BaseAbilityItem
 {
-	[Property, Group("Info")] public override string AbilityName { get; set; } = "Weapon";
+	[Property, Group( "Info" )] public override string AbilityName { get; set; } = "Weapon";
 	[Property, Group( "Info" )] public override string AbilityDescription { get; set; } = "Weapon";
 	[Property, ImageAssetPath, Group( "Info" )] public override string AbilityIcon { get; set; } = "ui/test/ability/ab1.png";
 	[Property, Group( "Stats" )] public override int MaxUseCount { get; set; } = 30;
@@ -26,10 +23,13 @@ public class BaseWeaponItem : BaseAbilityItem
 		PlayerStats = GameObject.Components.Get<Stats>( FindMode.InParent );
 		CurrentUseCount = MaxUseCount;
 
-		ViewModel = ViewModelObject.Components.Get<SkinnedModelRenderer>();
+		if ( ViewModelObject != null )
+		{
+			ViewModel = ViewModelObject.Components.Get<SkinnedModelRenderer>();
+		}
 		PlayerController = GameObject.Components.Get<PlayerController>( FindMode.InParent );
 
-		CrosshairUI = GameObject.Parent.Components.Get<BasicCrosshairUI>(FindMode.EverythingInChildren);
+		CrosshairUI = GameObject.Parent.Components.Get<BasicCrosshairUI>( FindMode.EverythingInChildren );
 	}
 
 	protected override void DrawGizmos()
@@ -57,7 +57,7 @@ public class BaseWeaponItem : BaseAbilityItem
 			LastFired = 0;
 			OnPrimaryFire();
 			base.DoFire();
-			CameraShake.Shake();
+			CameraShake?.Shake();
 			CrosshairUI.OnShoot();
 			var sprintcomp = PlayerController.Components.Get<SprintMechanic>( FindMode.EverythingInSelfAndChildren );
 			if ( sprintcomp != null )
@@ -87,12 +87,12 @@ public class BaseWeaponItem : BaseAbilityItem
 
 	public SceneTraceResult TraceBullet( Vector3 start, Vector3 end )
 	{
-		if(RandomSpread)
+		if ( RandomSpread )
 		{
 			end += Vector3.Random.Normal * Spread;
 		}
 
-		if(UseMuzzle)
+		if ( UseMuzzle )
 		{
 			Muzzle = ViewModelObject.Components.Get<SkinnedModelRenderer>().GetAttachment( "muzzle" ).Value.Position;
 			start = Muzzle;
@@ -105,9 +105,9 @@ public class BaseWeaponItem : BaseAbilityItem
 		return tr;
 	}
 
-	public virtual void OnHit(GameObject obj)
+	public virtual void OnHit( GameObject obj )
 	{
-		if(obj != null)
+		if ( obj != null )
 		{
 			var health = obj.Components.Get<Npcbase>();
 			{


### PR DESCRIPTION
Cleaned up InteractorUse to fix a bug that kept the use panel on the screen when not looking at an interactable, added a slight delay to prevent using two items in the same frame, and added a singleton to `ItemsUI` to make accessing it easier. 